### PR TITLE
Revert "Bump fastapi from 0.90.0 to 0.93.0 in /api"

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
 redis==4.5.1
 dynaconf==3.1.11
-fastapi==0.93.0
+fastapi==0.90.0
 uvicorn==0.20.0
 structlog==22.3.0


### PR DESCRIPTION
Reverts alivx/urless#129